### PR TITLE
:wrench: Gradle wrapper upgrade and optimizations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+    id 'java'
+}
 
 group = 'org.homer'
 version = '4.2.4'
@@ -8,8 +10,14 @@ description = """Neo4j Procedures for Graph Versioning"""
 sourceCompatibility = 11
 targetCompatibility = 11
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
+    options.fork = true
+    options.incremental = true
+}
+
+tasks.withType(Test).configureEach {
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 repositories {
@@ -17,11 +25,11 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'org.neo4j.test', name: 'neo4j-harness', version:'4.2.4'
-    testCompile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version:'4.2.3'
-    testCompile group: 'junit', name: 'junit', version:'4.12'
-    testCompile group: 'org.hamcrest', name: 'hamcrest-junit', version:'2.0.0.0'
-    testCompile group: 'org.mockito', name: 'mockito-core', version:'2.13.0'
-    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.16.0'
-    compile group: 'org.neo4j', name: 'neo4j', version:'4.2.4'
+    implementation group: 'org.neo4j', name: 'neo4j', version: '4.2.4'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.16.0'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-junit', version: '2.0.0.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.13.0'
+    testImplementation group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.2.3'
+    testImplementation group: 'org.neo4j.test', name: 'neo4j-harness', version: '4.2.4'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.caching=true
+org.gradle.daemon=true
+org.gradle.jvmargs=-Xmx2048M
+org.gradle.parallel=true
+org.gradle.vfs.watch=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- updated gradle wrapper to 7.0.2
- replaced the deprecated compile/testCompile dependencies with implementation/testImplementation
- added process forking for tasks of type JavaCompile; this improves performance of gradle daemon reducing the amount of garbage collection in its process
- added process forking for tests
- enabled build caching of inputs and outputs

Overall, I saw about a 50% reduction in build time from the above changes